### PR TITLE
Use the default value of FrameInterval

### DIFF
--- a/files/WUM.Patch.ini
+++ b/files/WUM.Patch.ini
@@ -1,5 +1,5 @@
 [Main]
-FrameInterval = 0       // Interval between frames (ms), experimental [Default = 16 = ~62 FPS]
+FrameInterval = 16      // Interval between frames (ms), experimental [Default = 16 = ~62 FPS]
 HudAspectRatioFix = 0   // Stretch HUD (for ultra-wide resolutions) [0 = false, 1 = true]
 DisableLetterbox = 0    // Removes letterboxing (for ultra-wide resolutions) [0 = false, 1 = true]
 XSceneCameraFix = 1     // Fixes bomber scene aspect ratio [0 = false, 1 = true]


### PR DESCRIPTION
In the WUM.Patch.ini file, since the current value (0) can cause flicker